### PR TITLE
Install logrotate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-RUN apk add --update rsyslog && \
+RUN apk add --update rsyslog logrotate && \
     rm -rf /var/cache/apk/*
 
 EXPOSE 514 514/udp


### PR DESCRIPTION
Currently, the rsyslog container does not do log rotation. This caused
one implementation hitting over 30gb in logs that need to be manually
cleaned (and a full disk).

Rsyslog installed here already comes with a logrotate configuration
that is placed in the /etc/corporate.d directory with a default weekly
clean-up schedule. The only problem is that logrotate itself is not
installed, so no log rotation is occurring.

Hence, the quick fix is to just install logrotate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-rsyslog/1)
<!-- Reviewable:end -->
